### PR TITLE
优化批量处理失败重试机制并调整批量参数

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -17,25 +17,25 @@ API_KEY_BATCH = "sk-cxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx01"
 MIN_BATCH_THRESHOLD = 5
 
 # batch 单次推荐批量数（平衡效率与稳定性）
-RECOMMENDED_BATCH_SIZE = 100
+RECOMMENDED_BATCH_SIZE = 25
 
 # batch 单次最大批量数（保守设置，远低于阿里云 50,000 限制）
-MAX_BATCH_SIZE = 1000
+MAX_BATCH_SIZE = 50
 
 # batch 单文件最大大小限制（阿里云限制 500 MB，我们设置为 80% 即 400 MB）
-MAX_BATCH_FILE_SIZE_MB = 400
+MAX_BATCH_FILE_SIZE_MB = 300
 
 # batch 单个 JSON 对象最大大小（阿里云限制 6 MB，我们设置为 5 MB）
-MAX_SINGLE_REQUEST_SIZE_MB = 5
+MAX_SINGLE_REQUEST_SIZE_MB = 4
 
 # batch 文件大小估算安全系数（预留 20-30% 余量）
-BATCH_SIZE_SAFETY_FACTOR = 0.75
+BATCH_SIZE_SAFETY_FACTOR = 0.6
 
 # 轮询间隔（秒）
 POLL_INTERVAL = 40
 
 # 最大等待时间（秒）
-MAX_WAIT_TIME = 18000
+MAX_WAIT_TIME = 3600
 
 DEFAULT_CONFIG_PATH = "config/models_config.json"  # 模型配置文件路径
 

--- a/infra/ai_client.py
+++ b/infra/ai_client.py
@@ -376,8 +376,22 @@ class AIHubClient:
                 
             except Exception as e:
                 logger.error(f"❌ 批次 {current_batch_num} 处理失败: {e}")
-                all_results.extend([None] * len(batch))
-        
+                
+                if retry_failed:
+                    logger.warning(
+                        f"⚠️ 批次 {current_batch_num} 整体失败，降级为单调用重试 {len(batch)} 个任务..."
+                    )
+                    retry_results = self._fallback_to_single_calls(
+                        batch, model, require_json, max_tokens, temperature, **kwargs
+                    )
+                    all_results.extend(retry_results)
+                    logger.info(
+                        f"✅ 批次 {current_batch_num} 重试完成 | "
+                        f"成功: {sum(1 for r in retry_results if r is not None)}/{len(retry_results)}"
+                    )
+                else:
+                    all_results.extend([None] * len(batch))
+
         logger.info(f"✅ 批量调用完成 | 成功: {sum(1 for r in all_results if r is not None)}/{len(all_results)}")
         return all_results
     
@@ -434,12 +448,16 @@ class AIHubClient:
             messages = item.get("messages", [])
             params = item.get("params", {})
             
+            cleaned_params = {**params}
+            cleaned_params.pop('max_tokens', None)
+            cleaned_params.pop('temperature', None)
+            
             request_body = {
-                "model": "placeholder",  # 占位符，实际大小差异不大
+                "model": "placeholder",
                 "messages": messages,
                 "max_tokens": params.get("max_tokens", 2048),
                 "temperature": params.get("temperature", 0.1),
-                **params
+                **cleaned_params
             }
             
             jsonl_line = {
@@ -449,11 +467,9 @@ class AIHubClient:
                 "body": request_body
             }
             
-            # 计算 JSON 字符串的 UTF-8 编码字节数
             json_str = json.dumps(jsonl_line, ensure_ascii=False)
-            total_bytes += len(json_str.encode('utf-8')) + 1  # +1 为换行符
+            total_bytes += len(json_str.encode('utf-8')) + 1
         
-        # 转换为 MB
         total_mb = total_bytes / (1024 * 1024)
         return total_mb
     
@@ -523,13 +539,16 @@ class AIHubClient:
                 messages = item.get("messages", [])
                 params = item.get("params", {})
                 
+                merged_params = {**params, **kwargs}
+                merged_params.pop('max_tokens', None)
+                merged_params.pop('temperature', None)
+                
                 response = self._client.chat.completions.create(
                     model=selected_model,
                     messages=messages,
                     max_tokens=max_tokens,
                     temperature=temperature,
-                    **params,
-                    **kwargs
+                    **merged_params
                 )
                 
                 raw_text = response.choices[0].message.content
@@ -561,12 +580,16 @@ class AIHubClient:
             messages = item.get("messages", [])
             params = item.get("params", {})
             
+            cleaned_params = {**params}
+            cleaned_params.pop('max_tokens', None)
+            cleaned_params.pop('temperature', None)
+            
             request_body = {
                 "model": model,
                 "messages": messages,
                 "max_tokens": max_tokens,
                 "temperature": temperature,
-                **params
+                **cleaned_params
             }
             
             if require_json:
@@ -613,7 +636,7 @@ class AIHubClient:
                     os.unlink(temp_file)
                 except:
                     pass
-    
+
     def _upload_batch_file(self, file_path: str) -> Optional[str]:
         """上传 JSONL 文件到 DashScope"""
         try:


### PR DESCRIPTION
- 添加批量失败时降级为单次调用重试的功能
- 实现批量请求参数清理避免重复设置max_tokens和temperature
- 减少推荐批量大小从100到25，最大批量从1000到50
- 降低批量文件大小限制从400MB到300MB
- 缩短最大等待时间从18000秒到3600秒
- 移除多余的注释代码